### PR TITLE
Make use of new vendor file process

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,4 @@
-@files=[
-  { 'sha1' => 'a90fe6cc53b76b7bdd56dc57950d90787cb9c96e', 'url' => 'https://collectd.org/files/collectd-5.4.0.tar.gz', 'files' => [ '/src/types.db' ] }
-  ]
+@files=[]
 
 task :default do
   system("rake -T")

--- a/vendor.json
+++ b/vendor.json
@@ -1,0 +1,5 @@
+[{
+        "sha1": "a90fe6cc53b76b7bdd56dc57950d90787cb9c96e",
+        "url": "https://collectd.org/files/collectd-5.4.0.tar.gz",
+        "files": [ "/src/types.db" ]
+}]


### PR DESCRIPTION
Using vendor.json file we let the plugin installer take care of any vendor files that require downloading
