### PR TITLE
Documentation: Fix port typo in collectd.asciidoc

### DIFF
--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -18,7 +18,7 @@ class NaNError < LogStash::Error; end
 # [source,ruby]
 #     input {
 #       udp {
-#         port => 28526
+#         port => 25826
 #         buffer_size => 1452
 #         codec => collectd { }
 #       }


### PR DESCRIPTION
I believe there is a typo in the example config.
