### PR TITLE
Fix for #6

### DIFF
--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -72,6 +72,7 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
   PLUGIN_TYPE_FIELDS = {
     'host' => true,
     '@timestamp' => true,
+    'type_instance' => true,
   }
 
   COLLECTD_TYPE_FIELDS = {
@@ -117,18 +118,18 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
   # collectd https://collectd.org/wiki/index.php/Plugin:Network[Network plugin]
   config :security_level, :validate => [SECURITY_NONE, SECURITY_SIGN, SECURITY_ENCR],
     :default => "None"
-  
+
   # What to do when a value in the event is `NaN` (Not a Number)
   #
   # - change_value (default): Change the `NaN` to the value of the nan_value option and add `nan_tag` as a tag
   # - warn: Change the `NaN` to the value of the nan_value option, print a warning to the log and add `nan_tag` as a tag
   # - drop: Drop the event containing the `NaN` (this only drops the single event, not the whole packet)
   config :nan_handling, :validate => ['change_value','warn','drop'], :default => 'change_value'
-  
+
   # Only relevant when `nan_handeling` is set to `change_value`
   # Change NaN to this configured value
   config :nan_value, :validate => :number, :default => 0
-  
+
   # The tag to add to the event if a `NaN` value was found
   # Set this to an empty string ('') if you don't want to tag
   config :nan_tag, :validate => :string, :default => '_collectdNaN'
@@ -396,7 +397,7 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
       length  = ((payload.slice!(0) << 8) + payload.slice!(0)) - 4
       # Validate that the part length is correct
       raise(HeaderError) if length > payload.length
-      
+
       body = payload.slice!(0..length-1)
 
       field = TYPEMAP[typenum]

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-collectd'
-  s.version         = '0.1.4'
+  s.version         = '0.1.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from the connectd binary protocol"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -24,4 +24,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.name            = 'logstash-codec-collectd'
   s.version         = '0.1.5'
   s.licenses        = ['Apache License (2.0)']
-  s.summary         = "Read events from the connectd binary protocol"
+  s.summary         = "Read events from the collectd binary protocol"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elasticsearch"]
   s.email           = 'info@elasticsearch.com'

--- a/vendor.json
+++ b/vendor.json
@@ -1,5 +1,5 @@
 [{
         "sha1": "a90fe6cc53b76b7bdd56dc57950d90787cb9c96e",
-        "url": "https://collectd.org/files/collectd-5.4.0.tar.gz",
+        "url": "http://collectd.org/files/collectd-5.4.0.tar.gz",
         "files": [ "/src/types.db" ]
 }]


### PR DESCRIPTION
This fix corrects the scenario described in #6 

It also clears out some blank lines with spaces (Atom editor automatically does this), corrects a typo, and makes it easier to do the `rake vendor` call.
