### PR TITLE
1.0.1 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
+# 1.0.1
+  * Bug fix release including the necessary vendored files.
 # 0.1.10
   * Ensure that notifications make it through.  Reported in #10

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-collectd'
-  s.version         = '1.0.0'
+  s.version         = '1.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from the collectd binary protocol"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
 to release a new gem, this time including the necessary vendored files to run this codec properly.

This helps fixing  one of the issues raised in: https://github.com/elastic/logstash/issues/3527
