### PR TITLE
synchronize access to OpenSSL::Cipher, use digest package for digests, fix metric mangling under high load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.2
+  * sync access to OpenSSL::Cipher (not thread-safe)
+  * use Digest for digests instead of OpenSSL::Digest and OpenSSL::HMAC (not thread-safe)
+  * fix collectd packet mangling under high load conditions
 # 1.0.1
   * Bug fix release including the necessary vendored files.
 # 0.1.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 1.0.2
-  * sync access to OpenSSL::Cipher (not thread-safe)
+# 2.0.0
+  * synchronize access to OpenSSL::Cipher (not thread-safe)
   * use Digest for digests instead of OpenSSL::Digest and OpenSSL::HMAC (not thread-safe)
   * fix collectd packet mangling under high load conditions
 # 1.0.1

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ Contributors:
 * Richard Pijnenburg (electrical)
 * Suyog Rao (suyograo)
 * andis
+* Frank de Jong (frapex)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -340,7 +340,7 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
     key = get_key(user)
     return false if key.nil?
 
-    return OpenSSL::HMAC.digest(@sha256, key, user+payload) == signature
+    return Digest::HMAC.digest(user+payload, key, Digest::SHA256) == signature
   end # def verify_signature
 
   private


### PR DESCRIPTION
1) synchronize access to OpenSSL::Cipher and use digest package for digests, because OpenSSL::Digest and OpenSSL::Cipher are not thread safe.

Refer to issue https://github.com/logstash-plugins/logstash-codec-collectd/issues/14 for more information.

2) Fix metric mangling under high load

The plugin mangles collectd metrics under some conditions.
The bug is triggered when (for example) the percent metrics are send in rapid succession, one after another.

Refer to issue https://github.com/logstash-plugins/logstash-codec-collectd/issues/15 for more information.
