### PR TITLE
Make this Plugin compatible with JRuby 9k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.4
+  - Make this plugins compatible with JRuby 9 by using the OpenSSL::HMAC class and keep it backward compatible with JRuby 1.7.25 (Issue #24)
+
 ## 3.0.3
   - Fix log levels
 

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-codec-collectd'
-  s.version         = '3.0.3'
+  s.version         = '3.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from the collectd binary protocol"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
With the upgrade to JRuby 9k, the HMAC class was moved under the OpenSSL
namespace and the signature was changed, this commit make sure the
plugin still work under JRuby-1.7.X by creating the right method when
the class is loaded into memory.
