### PR TITLE
fix vendoring of types.db file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.6
+  - Return types.db to the list of items to be included in the gem
+
+## 3.0.5
+  - Minor documentation changes for better flow and understanding
+
 ## 3.0.4
   - Make this plugins compatible with JRuby 9 by using the OpenSSL::HMAC class and keep it backward compatible with JRuby 1.7.25 (Issue #24)
 

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-codec-collectd'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from the collectd binary protocol"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/jar-dependencies/**/*.jar", "vendor/jar-dependencies/**/*.rb", "VERSION", "docs/**/*"]
+  s.files = Dir["lib/**/*","spec/**/*","*.gemspec","*.md","CONTRIBUTORS","Gemfile","LICENSE","NOTICE.TXT", "vendor/types.db", "VERSION", "docs/**/*"]
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
includes types.db in the list of things to pack in the .gem

version 3.0.4 and 3.0.5 must be yanked as they're broken due to the lack of this file in the gem:


```
% for gem in logstash-codec-collectd-3.0.*; do gem unpack $gem; done
Unpacked gem: '/private/tmp/logstash-codec-collectd-3.0.3'
Unpacked gem: '/private/tmp/logstash-codec-collectd-3.0.4'
Unpacked gem: '/private/tmp/logstash-codec-collectd-3.0.5'
% find logstash-codec-collectd-3.0.* -name '*.db'
logstash-codec-collectd-3.0.3/vendor/types.db
```