### PR TITLE
Feat: added target configuration + event-factory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Feat: added target configuration + event-factory support [#31](https://github.com/logstash-plugins/logstash-codec-collectd/pull/31)
+
 ## 3.0.8
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -53,7 +53,7 @@ Be sure to replace `10.0.0.1` with the IP of your Logstash instance.
 
 
 [id="plugins-{type}s-{plugin}-options"]
-==== Collectd Codec Configuration Options
+==== Collectd Codec configuration options
 
 [cols="<,<,<",options="header",]
 |=======================================================================

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -64,6 +64,7 @@ Be sure to replace `10.0.0.1` with the IP of your Logstash instance.
 | <<plugins-{type}s-{plugin}-nan_value>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-prune_intervals>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-security_level>> |<<string,string>>, one of `["None", "Sign", "Encrypt"]`|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-typesdb>> |<<array,array>>|No
 |=======================================================================
 
@@ -126,6 +127,26 @@ Prune interval records.  Defaults to `true`.
 
 Security Level. Default is `None`. This setting mirrors the setting from the
 collectd https://collectd.org/wiki/index.php/Plugin:Network[Network plugin]
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Define the target field for placing the decoded values. If this setting is not
+set, data will be stored at the root (top level) of the event.
+
+For example, if you want data to be put under the `document` field:
+[source,ruby]
+    input {
+      udp {
+        port => 12345
+        codec => collectd {
+          target => "[document]"
+        }
+      }
+    }
 
 [id="plugins-{type}s-{plugin}-typesdb"]
 ===== `typesdb` 

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -110,8 +110,7 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
 
   # Security Level. Default is `None`. This setting mirrors the setting from the
   # collectd https://collectd.org/wiki/index.php/Plugin:Network[Network plugin]
-  config :security_level, :validate => [SECURITY_NONE, SECURITY_SIGN, SECURITY_ENCR],
-    :default => "None"
+  config :security_level, :validate => [SECURITY_NONE, SECURITY_SIGN, SECURITY_ENCR], :default => "None"
 
   # What to do when a value in the event is `NaN` (Not a Number)
   #

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -489,7 +489,7 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
     end # while payload.length > 0 do
   rescue EncryptionError, ProtocolError, HeaderError, NaNError => e
     # basically do nothing, we just want out
-    @logger.debug("Decode failure", payload: payload, exception: e.class, message: e.message)
+    @logger.debug("Decode failure", payload: payload, message: e.message)
   end # def decode
 
 end # class LogStash::Codecs::Collectd

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -488,8 +488,9 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
         end
       end
     end # while payload.length > 0 do
-  rescue EncryptionError, ProtocolError, HeaderError, NaNError
+  rescue EncryptionError, ProtocolError, HeaderError, NaNError => e
     # basically do nothing, we just want out
+    @logger.debug("Decode failure", payload: payload, exception: e.class, message: e.message)
   end # def decode
 
 end # class LogStash::Codecs::Collectd

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -6,6 +6,8 @@ require "logstash/errors"
 require "tempfile"
 require "time"
 
+require 'logstash/plugin_mixins/event_support/event_factory_adapter'
+
 # Read events from the collectd binary protocol over the network via udp.
 # See https://collectd.org/wiki/index.php/Binary_protocol
 #
@@ -38,6 +40,9 @@ require "time"
 # Be sure to replace `10.0.0.1` with the IP of your Logstash instance.
 #
 class LogStash::Codecs::Collectd < LogStash::Codecs::Base
+
+  include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
+
   config_name "collectd"
 
   class ProtocolError < LogStash::Error; end
@@ -472,7 +477,7 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
           # This ugly little shallow-copy hack keeps the new event from getting munged by the cleanup
           # With pass-by-reference we get hosed (if we pass collectd, then clean it up rapidly, values can disappear)
           if !drop # Drop the event if it's flagged true
-            yield LogStash::Event.new(collectd.dup)
+            yield event_factory.new_event(collectd.dup)
           else
             raise(NaNError)
           end

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -33,8 +33,7 @@ require 'logstash/plugin_mixins/event_support/event_factory_adapter'
 #         IgnoreSelected false
 #     </Plugin>
 #     <Plugin network>
-#         <Server "10.0.0.1" "25826">
-#         </Server>
+#         Server "10.0.0.1" "25826"
 #     </Plugin>
 #
 # Be sure to replace `10.0.0.1` with the IP of your Logstash instance.

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -6,11 +6,6 @@ require "logstash/errors"
 require "tempfile"
 require "time"
 
-class ProtocolError < LogStash::Error; end
-class HeaderError < LogStash::Error; end
-class EncryptionError < LogStash::Error; end
-class NaNError < LogStash::Error; end
-
 # Read events from the collectd binary protocol over the network via udp.
 # See https://collectd.org/wiki/index.php/Binary_protocol
 #
@@ -44,6 +39,11 @@ class NaNError < LogStash::Error; end
 #
 class LogStash::Codecs::Collectd < LogStash::Codecs::Base
   config_name "collectd"
+
+  class ProtocolError < LogStash::Error; end
+  class HeaderError < LogStash::Error; end
+  class EncryptionError < LogStash::Error; end
+  class NaNError < LogStash::Error; end
 
   @@openssl_mutex = Mutex.new
 

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -6,8 +6,6 @@ require "logstash/errors"
 require "tempfile"
 require "time"
 
-import "javax.crypto.Mac"
-
 class ProtocolError < LogStash::Error; end
 class HeaderError < LogStash::Error; end
 class EncryptionError < LogStash::Error; end

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-codec-collectd'
-  s.version         = '3.0.8'
+  s.version         = '3.0.9'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the `collectd` binary protocol using UDP."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-codec-collectd'
-  s.version         = '3.0.9'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the `collectd` binary protocol using UDP."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'insist'


### PR DESCRIPTION
This PR starts leveraging `event_factory` support in the codec plugin.
Also added an optional `config :target`.

Additionally we reduced the number of "global" constants this plugin introduces + added at least debug logging on errors.