### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+  - Fix: replace deprecated `File.exists?` with `File.exist?` for Ruby 3.4 (JRuby 10) compatibility [#36](https://github.com/logstash-plugins/logstash-codec-collectd/pull/36)
+
 ## 3.1.0
   - Feat: added target configuration + event-factory support [#31](https://github.com/logstash-plugins/logstash-codec-collectd/pull/31)
 

--- a/lib/logstash/codecs/collectd.rb
+++ b/lib/logstash/codecs/collectd.rb
@@ -148,7 +148,7 @@ class LogStash::Codecs::Collectd < LogStash::Codecs::Base
     init_lambdas!
     if @typesdb.nil?
       @typesdb = ::File.expand_path('../../../vendor/types.db', ::File.dirname(__FILE__))
-      if !File.exists?(@typesdb)
+      if !File.exist?(@typesdb)
         raise "You must specify 'typesdb => ...' in your collectd input (I looked for '#{@typesdb}')"
       end
       @logger.debug("Using types.db", :typesdb => @typesdb.to_s)

--- a/logstash-codec-collectd.gemspec
+++ b/logstash-codec-collectd.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-codec-collectd'
-  s.version         = '3.1.0'
+  s.version         = '3.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the `collectd` binary protocol using UDP."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Summary
- Replace `File.exists?` with `File.exist?` for Ruby 3.4 compatibility

`File.exists?` was deprecated in Ruby 3.2 and has been removed in Ruby 3.4 (JRuby 10). `File.exist?` has been the preferred method since Ruby 1.0.